### PR TITLE
Allow arbitrary key sizes for HMAC keys

### DIFF
--- a/lib/src/appleMain/kotlin/com/icure/kryptom/crypto/IosHmacService.kt
+++ b/lib/src/appleMain/kotlin/com/icure/kryptom/crypto/IosHmacService.kt
@@ -10,9 +10,13 @@ import platform.CoreCrypto.kCCHmacAlgSHA256
 import platform.CoreCrypto.kCCHmacAlgSHA512
 
 object IosHmacService : HmacService {
-	override suspend fun <A : HmacAlgorithm> generateKey(algorithm: A, keySize: Int?): HmacKey<A> {
-		require(keySize == null || keySize >= algorithm.minimumKeySize) {
-			"Invalid key size for $algorithm. A minimal length of ${algorithm.minimumKeySize} is required"
+	override suspend fun <A : HmacAlgorithm> generateKey(
+		algorithm: A,
+		keySize: Int?,
+		acceptsShortKeySize: Boolean
+	): HmacKey<A> {
+		require(acceptsShortKeySize || keySize == null || keySize >= algorithm.minimumRecommendedKeySize) {
+			"Invalid key size for $algorithm. A minimal length of ${algorithm.minimumRecommendedKeySize} is required"
 		}
 		return HmacKey(IosStrongRandom.randomBytes(keySize ?: algorithm.recommendedKeySize), algorithm)
 	}
@@ -21,9 +25,13 @@ object IosHmacService : HmacService {
 	override suspend fun exportKey(key: HmacKey<*>): ByteArray =
 		key.rawKey.copyOf()
 
-	override suspend fun <A : HmacAlgorithm> loadKey(algorithm: A, bytes: ByteArray): HmacKey<A> {
-		require(bytes.size >= algorithm.minimumKeySize) {
-			"Invalid key length for algorithm $algorithm: got ${bytes.size} but at least ${algorithm.minimumKeySize} expected"
+	override suspend fun <A : HmacAlgorithm> loadKey(
+		algorithm: A,
+		bytes: ByteArray,
+		acceptsShortKeys: Boolean
+	): HmacKey<A> {
+		require(acceptsShortKeys || bytes.size >= algorithm.minimumRecommendedKeySize) {
+			"Invalid key length for algorithm $algorithm: got ${bytes.size} but at least ${algorithm.minimumRecommendedKeySize} expected"
 		}
 		return HmacKey(bytes.copyOf(), algorithm)
 	}

--- a/lib/src/commonMain/kotlin/com/icure/kryptom/crypto/HmacService.kt
+++ b/lib/src/commonMain/kotlin/com/icure/kryptom/crypto/HmacService.kt
@@ -6,10 +6,15 @@ interface HmacService {
 	 *
 	 * @param algorithm the [HmacAlgorithm].
 	 * @param keySize the key size. If null (default behaviour), [HmacAlgorithm.recommendedKeySize] will be used.
-	 * Note: for security reasons, the key size cannot be less than [HmacAlgorithm.minimumKeySize]
-	 * @throws IllegalArgumentException if [keySize] is less than [HmacAlgorithm.minimumKeySize]
+	 * Note: for general usage the key size shouldn't be less than [HmacAlgorithm.minimumRecommendedKeySize], but in
+	 * some applications (e.g. TOTP shorter lengths are acceptable)
+	 * @param acceptsShortKeySize if false (default) key sizes shorter than the minimum recommended key size for the algorithm will be rejected
 	 */
-	suspend fun <A : HmacAlgorithm> generateKey(algorithm: A, keySize: Int? = null): HmacKey<A>
+	suspend fun <A : HmacAlgorithm> generateKey(
+		algorithm: A,
+		keySize: Int? = null,
+		acceptsShortKeySize: Boolean = false
+	): HmacKey<A>
 
 	/**
 	 * Exports a key to a byte array.
@@ -18,8 +23,13 @@ interface HmacService {
 
 	/**
 	 * Imports a key from a byte array.
+	 * @param acceptsShortKey if false (default) keys shorter than the minimum recommended key size for the algorithm will be rejected
 	 */
-	suspend fun <A : HmacAlgorithm> loadKey(algorithm: A, bytes: ByteArray): HmacKey<A>
+	suspend fun <A : HmacAlgorithm> loadKey(
+		algorithm: A,
+		bytes: ByteArray,
+		acceptsShortKeys: Boolean = false
+	): HmacKey<A>
 
 	/**
 	 * Generates a signature for some data using the provided key and algorithm.

--- a/lib/src/commonMain/kotlin/com/icure/kryptom/crypto/Keys.kt
+++ b/lib/src/commonMain/kotlin/com/icure/kryptom/crypto/Keys.kt
@@ -202,7 +202,7 @@ sealed interface HmacAlgorithm {
 	 * The minimum key size for this algorithm in bytes, as specified in the [HMAC RFC](https://www.rfc-editor.org/rfc/rfc2104#section-3).
 	 * A key which size is under this length decrease the security strength of the function.
 	 */
-	val minimumKeySize: Int
+	val minimumRecommendedKeySize: Int
 
 	/**
 	 * The size of the digest produced by this algorithm in bytes.
@@ -219,7 +219,7 @@ sealed interface HmacAlgorithm {
 	 */
 	data object HmacSha512 : HmacAlgorithm {
 		override val recommendedKeySize: Int = 128
-		override val minimumKeySize: Int = 64
+		override val minimumRecommendedKeySize: Int = 64
 		override val digestSize: Int = 64
 		override val identifier: String = Identifiers.HMAC_SHA_512
 	}
@@ -229,7 +229,7 @@ sealed interface HmacAlgorithm {
 	 */
 	data object HmacSha256 : HmacAlgorithm {
 		override val recommendedKeySize: Int = 64
-		override val minimumKeySize: Int = 32
+		override val minimumRecommendedKeySize: Int = 32
 		override val digestSize: Int = 32
 		override val identifier: String = Identifiers.HMAC_SHA_256
 	}

--- a/lib/src/commonTest/kotlin/com/icure/kryptom/crypto/HmacServiceTest.kt
+++ b/lib/src/commonTest/kotlin/com/icure/kryptom/crypto/HmacServiceTest.kt
@@ -62,14 +62,14 @@ class HmacServiceTest : StringSpec({
 		}
 
 		"$algorithm - can generate a key with a custom size" {
-			val size = algorithm.minimumKeySize
+			val size = algorithm.minimumRecommendedKeySize
 			val key = defaultCryptoService.hmac.generateKey(algorithm, size)
 			defaultCryptoService.hmac.exportKey(key).size shouldBe size
 		}
 
 		"$algorithm - cannot specify a key size less than the minimum key size" {
 			shouldThrow<IllegalArgumentException> {
-				defaultCryptoService.hmac.generateKey(algorithm, algorithm.minimumKeySize - 1)
+				defaultCryptoService.hmac.generateKey(algorithm, algorithm.minimumRecommendedKeySize - 1)
 			}
 		}
 


### PR DESCRIPTION
Needed by some special use cases like TOTP